### PR TITLE
Add issure templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/proposal.md
+++ b/.github/ISSUE_TEMPLATE/proposal.md
@@ -1,0 +1,45 @@
+---
+name: Proposal
+about: To suggest an idea for a new resource or process that will improve cloud native environmental sustainability that you want to work on (if you have an idea that you don't personally want to work on, make a "suggestion")
+title: "[Proposal] Project Name"
+labels: "proposal, triage-required"
+assignees: ''
+
+---
+
+<!-- Thank you for contributing to the WG!
+    Please remind that an issue is not the place to ask a question.
+    The README documents how to reach us https://github.com/cncf/wg-env-sustainability#meetings! 
+    Thank you :) -->
+
+#### Description
+<!-- Describe your idea here -->
+
+...
+
+#### Impact
+<!-- Describe your hopes for how this would reduce risk for the cloud native ecosystem.
+    Who will this help? How will it help them? -->
+
+...
+
+#### Scope
+<!-- How much effort will this take? ok to provide a range of options if or "not yet determined" for initial proposals.
+    Feel free to include proposed tasks below or link a Google doc  -->
+
+...
+
+### TODO
+
+- [ ] WG Env-Sustainability lead representative:
+- [ ] Project leader(s):
+- [ ] Project Members:
+- [ ] _Fill in addition TODO items here so the project team and community can see progress!_
+- [ ] Scope 
+- [ ] Deliverable(s)
+- [ ] Project Schedule
+- [ ] Slack Channel (as needed)
+- [ ] Meeting Time & Day:
+- [ ] Meeting Notes (link)
+- [ ] Meeting Details (zoom or hangouts link)
+- [ ] Retrospective

--- a/.github/ISSUE_TEMPLATE/suggestion.md
+++ b/.github/ISSUE_TEMPLATE/suggestion.md
@@ -1,0 +1,33 @@
+---
+name: Suggestion
+about: You have an idea for a new resource or process that will improve cloud native environment sustainability and you aren't sure if you are the person to work on it or want to get feedback from others to refine the idea
+title: "[Suggestion] some descriptive title"
+labels: "suggestion, triage-required"
+assignees: ''
+
+---
+
+<!-- Thank you for contributing to the WG!
+    Please remind that an issue is not the place to ask a question.
+    The README documents how to reach us https://github.com/cncf/wg-env-sustainability#meetings! 
+    Thank you :) -->
+
+#### Description
+<!-- describe your idea here -->
+
+...
+
+#### Impact
+<!-- Describe your hopes for how this would reduce risk for the cloud native ecosystem. Who will this help? How will it help them? -->
+
+...
+
+#### Scope
+<!-- How much effort will this take? ok to provide a range of options if or "not yet determined"  -->
+
+...
+
+#### Additional info and comments
+- Reference to supporting material: `NONE`
+- Links to related site: `NONE`
+- Feel free to delete this section if you don't have more info: `NONE`


### PR DESCRIPTION
Signed-off-by: leonardpahlke <leonard.pahlke@googlemail.com>

Adding two issue templates to which kinds of issues should be opened. Ref [Issue templates schema  from TAG Security](https://github.com/cncf/tag-security/tree/main/.github/ISSUE_TEMPLATE).

/assign @mkorbi 